### PR TITLE
Fix Lua table syntax for neovim config

### DIFF
--- a/content/zls/editors/vim/nvim-lspconfig.smd
+++ b/content/zls/editors/vim/nvim-lspconfig.smd
@@ -63,7 +63,7 @@ lspconfig.zls.setup {
       -- enable_build_on_save: true,
 
       -- omit the following line if `zig` is in your PATH
-      zig_exe_path: '/path/to/zig_executable'
+      zig_exe_path = '/path/to/zig_executable'
     }
   }
 }

--- a/content/zls/editors/vim/nvim-lspconfig.smd
+++ b/content/zls/editors/vim/nvim-lspconfig.smd
@@ -60,7 +60,7 @@ lspconfig.zls.setup {
       --
       -- Further information about build-on save:
       -- https://zigtools.org/zls/guides/build-on-save/
-      -- enable_build_on_save: true,
+      -- enable_build_on_save = true,
 
       -- omit the following line if `zig` is in your PATH
       zig_exe_path = '/path/to/zig_executable'
@@ -108,10 +108,10 @@ autocmd BufWritePre *.zig,*.zon lua vim.lsp.buf.format()
         --
         -- Further information about build-on save:
         -- https://zigtools.org/zls/guides/build-on-save/
-        -- enable_build_on_save: true,
+        -- enable_build_on_save = true,
 
         -- omit the following line if `zig` is in your PATH
-        zig_exe_path: '/path/to/zig_executable'
+        zig_exe_path = '/path/to/zig_executable'
       }
     }
   }


### PR DESCRIPTION
The `key:` syntax is a Lua syntax error. `key =` is correct.