### PR TITLE
Update Zed docs to set zls as the primary language server

### DIFF
--- a/content/zls/editors/zed.smd
+++ b/content/zls/editors/zed.smd
@@ -24,6 +24,8 @@ Add the following to your `settings.json`:
       // The Zig FAQ answers some questions about `zig fmt`:
       // https://github.com/ziglang/zig/wiki/FAQ
       "format_on_save": "language_server",
+      // Make sure that zls is the primary language server
+      "language_servers": ["zls", "..."]
       "code_actions_on_format": {
         // Run code actions that currently supports adding and removing discards.
         // "source.fixAll": true,


### PR DESCRIPTION
`zls` wasn't set as the primary language server for Zig till the latest release.

It was fixed in
https://github.com/zed-industries/zed/commit/ddc469ca3ef5ed30757278c527cfc3368ba7dbe1

But I added it here for people using older versions of Zed.