### PR TITLE
docs: typo in build-on-save

### DIFF
--- a/content/zls/guides/build-on-save.smd
+++ b/content/zls/guides/build-on-save.smd
@@ -26,7 +26,7 @@ Here is an example:
 >
 >The behaviour of ZLS 0.13.0 (anything before `0.14.0-dev.144+fcb8bcb5d` to be precise) is different from the current nightly build.
 >
->The `enable_build_on_save` option need to be enabled even if a "check" step is defined. The `build_on_save_args` is also no available. `build_on_save_step` needs to be used instead which can only specify the step name but no additional arguments.
+>The `enable_build_on_save` option need to be enabled even if a "check" step is defined. The `build_on_save_args` is also not available. `build_on_save_step` needs to be used instead which can only specify the step name but no additional arguments.
 
 ## Add a "check" step to your build.zig
 


### PR DESCRIPTION
fix small typo in build-on-save section