### PR TITLE
docs: add instruction for using zls nightly on neovim

### DIFF
--- a/content/zls/editors/vim.smd
+++ b/content/zls/editors/vim.smd
@@ -16,3 +16,5 @@ The following LSP plugins are documented:
 ># [Warning]($block.attrs('warning'))
 >
 >The [mason](https://github.com/williamboman/mason.nvim) package manager can only install the latest tagged release of ZLS which should **not** be used with Zig nightly/master.
+
+For neovim users who want to use nightly zls, you can install [`jinzhongjia/zig-lamp`](https://github.com/jinzhongjia/zig-lamp), which can install zls nightly through a simple command and parse `build.zig.zon`, add or remove dependency.


### PR DESCRIPTION
Now, we can easily install zls nightly through `zig-lamp`.

It is implemented with reference to release-worker`.